### PR TITLE
UNSC armor rebalance + antag text modification

### DIFF
--- a/code/modules/halo/clothing/marine.dm
+++ b/code/modules/halo/clothing/marine.dm
@@ -56,17 +56,21 @@
 	icon_state = "M52B Body Armor regular"
 	blood_overlay_type = "armor"
 	body_parts_covered = ARMS|UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 50, bullet = 45, laser = 40, energy = 40, bomb = 35, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 45, laser = 40, energy = 30, bomb = 35, bio = 0, rad = 0)
 	var/slots = 4
 	var/max_w_class = ITEM_SIZE_SMALL
-	armor_thickness = 20
+	armor_thickness = 25
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/flame/lighter)
 	starting_accessories = /obj/item/clothing/accessory/holster/hip
+
+/obj/item/clothing/suit/storage/marine/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.5 //for reference, riot armor is 1.0. UNSC are designed to be very defensive in nature, and have much better armor then the URF.
 
 /obj/item/clothing/suit/storage/marine/military_police
 	name = "M52B Body Armor NavSec"
 	desc = "An armored protective vest worn by the members of the UNSC Marine Corps. This one is modified for the use of naval security officers."
-	armor = list(melee = 50, bullet = 50, laser = 40, energy = 40, bomb = 35, bio = 0, rad = 0)
+	armor = list(melee = 70, bullet = 40, laser = 30, energy = 40, bomb = 35, bio = 0, rad = 0) //No slowdown, but worse stats. Designed for dealing with civillians and rogue marines.
 	armor_thickness = 20
 
 /obj/item/clothing/suit/storage/marine/medic
@@ -104,7 +108,7 @@
 	icon = 'code/modules/halo/clothing/marine_items.dmi'
 	icon_state = "UNSC Marine Ammo Belt item"
 	item_state = "UNSC Marine Ammo Belt"
-	storage_slots = 6
+	storage_slots = 8
 
 	can_hold = list(/obj/item/ammo_magazine,/obj/item/ammo_box,/obj/item/weapon/grenade/frag/m9_hedp,/obj/item/weapon/grenade/smokebomb,/obj/item/weapon/grenade/chem_grenade/incendiary)
 
@@ -116,7 +120,7 @@
 	icon_override = MARINE_OVERRIDE
 	icon_state = "UNSC Marine Medical Belt item"
 	item_state = "UNSC Marine Medical Belt"*/
-	storage_slots = 5
+	storage_slots = 8
 
 	can_hold = list(/obj/item/ammo_magazine/m5,/obj/item/ammo_magazine/m127_saphp,/obj/item/ammo_magazine/m127_saphe,/obj/item/weapon/storage/firstaid/unsc)
 
@@ -142,7 +146,7 @@
 	item_state = "salvage_void"
 	w_class = ITEM_SIZE_HUGE
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/weapon/tank)
-	armor = list(melee = 60, bullet = 30, laser = 60, energy = 25, bomb = 30, bio = 100, rad = 100)
+	armor = list(melee = 60, bullet = 10, laser = 60, energy = 25, bomb = 30, bio = 100, rad = 100) //Designed for repairing hulls, not combat
 
 /obj/item/clothing/head/helmet/space/void/unsc
 	name = "\improper Salvage Helmet"
@@ -212,10 +216,14 @@
 	icon_state = "body"
 	item_flags = STOPPRESSUREDAMAGE|AIRTIGHT
 	siemens_coefficient = 0.6
-	armor_thickness = 20
+	armor_thickness = 25
 	w_class = ITEM_SIZE_HUGE
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/weapon/tank)
-	armor = list(melee = 55, bullet = 40, laser = 25, energy = 25, bomb = 30, bio = 100, rad = 100)
+	armor = list(melee = 50, bullet = 40, laser = 25, energy = 25, bomb = 30, bio = 100, rad = 100) //Slightly worse stats then regualr UNSC armor, but spaceproof
+
+/obj/item/clothing/suit/spaceeva/eva/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 1 //Same slowdown as riot armor. The slowdown is mostly negated in space, where this suit is intended to be used in.
 
 /obj/item/clothing/head/helmet/eva/marine
 	name = "\improper EVA Marine Helmet"
@@ -227,7 +235,7 @@
 	item_state = "eva"
 	icon_state = "eva"
 	item_flags = STOPPRESSUREDAMAGE|AIRTIGHT
-	armor = list(melee = 55, bullet = 25, laser = 55,energy = 25, bomb = 15, bio = 100, rad = 50)
+	armor = list(melee = 50, bullet = 25, laser = 55,energy = 25, bomb = 15, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 
 	integrated_hud = /obj/item/clothing/glasses/hud/tactical

--- a/code/modules/halo/clothing/odst.dm
+++ b/code/modules/halo/clothing/odst.dm
@@ -3,7 +3,7 @@
 
 /obj/item/clothing/under/unsc/odst_jumpsuit
 	name = "ODST jumpsuit"
-	desc = "standard issue ODST jumpsuits, padded to provide a slight edge."
+	desc = "standard issue ODST jumpsuits. Unlikely to protect against anything more than a splinter."
 	icon = ITEM_INHAND
 	icon_override = ODST_OVERRIDE
 	item_state = "Jumpsuit"
@@ -15,12 +15,12 @@
 		)
 
 /obj/item/clothing/glasses/hud/tactical/odst_hud
-	darkness_view = 4
+	darkness_view = 2 //Used to be 4. Changed to allow more URF strategies in the dark.
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 
 /obj/item/clothing/head/helmet/odst
 	name = "ODST Rifleman Helmet"
-	desc = "Standard issue short-EVA capable helmet issued to ODST forces"
+	desc = "Standard issue short-EVA capable helmet issued to ODST forces. The visor is easily cracked by ballistics, but is fairly resilient against plasma weaponry."
 	icon = ITEM_INHAND
 	icon_override = ODST_OVERRIDE
 	item_state = "Odst Helmet"
@@ -35,7 +35,7 @@
 	heat_protection = HEAD | FACE
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	armor = list(melee = 60, bullet = 35, laser = 25,energy = 25, bomb = 20, bio = 100, rad = 25)
+	armor = list(melee = 60, bullet = 30, laser = 60,energy = 60, bomb = 20, bio = 100, rad = 50) //tweaked to be better at fighting covenant then innies. Gives them a specific purpose, instead of just being "better marines"
 	item_icons = list(
 		slot_l_hand_str = null,
 		slot_r_hand_str = null,
@@ -52,12 +52,12 @@
 
 /obj/item/clothing/suit/armor/special/odst
 	name = "ODST Armour"
-	desc = "Lightweight, durable armour issued to Orbital Drop Shock Troopers for increased survivability in the field."
+	desc = "Fairly heavy, durable armour issued to Orbital Drop Shock Troopers for increased survivability in the field. Designed for engaging plasma weaponry, the suit suffers from somewhat weak protection against ballistics,"
 	icon = ITEM_INHAND
 	icon_state = "Odst Armour"
 	icon_override = ODST_OVERRIDE
 	blood_overlay_type = "armor"
-	armor = list(melee = 55, bullet = 50, laser = 55, energy = 45, bomb = 40, bio = 100, rad = 25)
+	armor = list(melee = 60, bullet = 40, laser = 65, energy = 70, bomb = 40, bio = 100, rad = 50)
 	//specials = list(/datum/armourspecials/internal_air_tank/human) This line is disabled untill a dev can fix the internals code for it.
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO | ARMS | LEGS
@@ -70,8 +70,10 @@
 		slot_l_hand_str = null,
 		slot_r_hand_str = null,
 		)
-	armor_thickness = 20
-
+	armor_thickness = 25
+/obj/item/clothing/suit/armor/special/odst/New()
+	..()
+	slowdown_per_slot[slot_wear_suit] = 0.5 //for reference, riot armor is 1.0. UNSC are designed to be very defensive in nature, and have much better armor then the URF.
 
 /obj/item/clothing/shoes/magboots/odst
 	name = "ODST Magboots"

--- a/code/modules/halo/insurrection/antagonist.dm
+++ b/code/modules/halo/insurrection/antagonist.dm
@@ -7,8 +7,8 @@
 	antag_indicator = "innie"
 	role_text_plural = "Insurrectionist"
 	landmark_id = "Insurrectionist-Spawn"
-	welcome_text = "You are a member of the Insurrectionist forces, down with the UNSC! Use :t to speak to the rest of your rebels."
-	leader_welcome_text = "You are the leader of the Insurrectionist forces, down with the UNSC! Use :t to speak to your underlings."
+	welcome_text = "You are a member of the Insurrectionist Brotherhood Cell. Down with the UNSC! Use :t to speak to the rest of your brothers."
+	leader_welcome_text = "You are the leader of the Insurrectionist forces, down with the UNSC! Use :t to speak to your homicidal freedom fighters."
 	welcome_text = "To speak on your group's private channel use :t."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_LEADER
 	id_type = /obj/item/weapon/card/id/insurrectionist


### PR DESCRIPTION
Part 2 of zerg's bizarre rebalance. Thickness of all UNSC combat gear has been increased to 25. For reference, URF thickness of standard armor is 20, and the collosus suit is 30. As a result of better protection, the UNSC armor (excluding MP) has been given slowdown. The values are experimental, and should be tweaked constantly to find a good balance (if they work at all).

🆑 Zergursh
tweak: Modifies marine armor to be more defensive and better against URF ballistics, but struggle against covenant plasma (which will be mostly limited to events). Slowdown has been added to better balance the new values
tweak: Modifies ODST armor to be more defensive and better against Covenant plasma weaponry, but struggle against most URF and UNSC ballistics. Gives them a different role other then just "better marine" as they were previously.
rscadd: For the Brotherhood!
/🆑
